### PR TITLE
Update README to show named import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ npm install use-reducer-async
 ## Usage
 
 ```javascript
+
+import { useReducerAsync } from "use-reducer-async";
+
 const initialState = {
   sleeping: false,
 };


### PR DESCRIPTION
It took me a few minutes to realize that there is no default import from use-reducer-async, and we have to use a named import. This is a one line change to prevent confusion for future users.