### PR TITLE
fix: useAbortSignal to work with React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - fix build for UMD
+- fix: useAbortSignal to work with React 18 #35
 
 ## [2.1.0] - 2021-12-23
 ### Changed

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useReducer,
   useRef,
+  useState,
   Dispatch,
   Reducer,
   ReducerState,
@@ -18,17 +19,17 @@ const isClient = (
 const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect;
 
 const useAbortSignal = () => {
-  const abortController = useRef<AbortController>();
-  if (!abortController.current) {
-    abortController.current = new AbortController();
-  }
+  const [controller, setController] = useState(() => new AbortController());
+  const lastController = useRef(controller);
   useEffect(() => {
     const abort = () => {
-      (abortController.current as AbortController).abort();
+      lastController.current.abort();
+      lastController.current = new AbortController();
+      setController(lastController.current);
     };
     return abort;
   }, []);
-  return abortController.current.signal;
+  return controller.signal;
 };
 
 export type AsyncActionHandlers<


### PR DESCRIPTION
React 18's strict effect indicates our previous `useAbortSignal` violates the rule. The new one work, but it will cause a re-render. I think it can't be helped.